### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,11 +12,11 @@ Arduino_POSIXStorage	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-mount                           KEYWORD2
-unmount                         KEYWORD2
-register_hotplug_callback       KEYWORD2
-deregister_hotplug_callback     KEYWORD2
-mkfs                            KEYWORD2
+mount	KEYWORD2
+unmount	KEYWORD2
+register_hotplug_callback	KEYWORD2
+deregister_hotplug_callback	KEYWORD2
+mkfs	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:

https://arduino.github.io/arduino-cli/latest/library-specification/#keywordstxt-format