### PR TITLE
Add extended callback support

### DIFF
--- a/extras/tests/Arduino_POSIXStorage_Test/Arduino_POSIXStorage_Test.ino
+++ b/extras/tests/Arduino_POSIXStorage_Test/Arduino_POSIXStorage_Test.ino
@@ -24,7 +24,7 @@ enum TestTypes : uint8_t
 
 // !!! TEST CONFIGURATION !!! -->
 
-constexpr enum TestTypes selectedTest = TEST_PORTENTA_H7_USB;
+constexpr enum TestTypes selectedTest = TEST_PORTENTA_C33_SDCARD;
 
 // Notice that formtting tests can take a while to complete
 
@@ -477,7 +477,7 @@ void setup() {
   if (DEV_USB == deviceName)
   {
     // Register multiple callbacks test (unplug) -->
-    retVal = register_unplug_callback(DEV_USB, usbCallback);
+    retVal = register_unplug_callback(DEV_USB, usbCallback2);
     if ((-1 != retVal) || (EBUSY != errno))
     {
       allTestsOk = false;

--- a/extras/tests/Arduino_POSIXStorage_Test/Arduino_POSIXStorage_Test.ino
+++ b/extras/tests/Arduino_POSIXStorage_Test/Arduino_POSIXStorage_Test.ino
@@ -24,7 +24,7 @@ enum TestTypes : uint8_t
 
 // !!! TEST CONFIGURATION !!! -->
 
-constexpr enum TestTypes selectedTest = TEST_PORTENTA_C33_SDCARD;
+constexpr enum TestTypes selectedTest = TEST_PORTENTA_H7_USB;
 
 // Notice that formtting tests can take a while to complete
 
@@ -35,10 +35,16 @@ constexpr enum TestTypes selectedTest = TEST_PORTENTA_C33_SDCARD;
 // <-- !!! TEST CONFIGURATION !!!
 
 volatile bool usbAttached = false;
+volatile bool usbDetached = false;
 
 void usbCallback()
 {
   usbAttached = true;
+}
+
+void usbCallback2()
+{
+  usbDetached = true;
 }
 
 void setup() {
@@ -104,60 +110,55 @@ void setup() {
   }
   // <-- Register hotplug callback for SD Card test
 
-  if (TEST_PORTENTA_C33_USB == selectedTest)
+  // Register unplug callback for SD Card test -->
+  if (DEV_SDCARD == deviceName)
   {
-    // Register nullptr callback test -->
+    // Using usbCallback2() is fine because it doesn't get registered anyway
+    retVal = register_unplug_callback(DEV_SDCARD, usbCallback2);
+    if ((-1 != retVal) || (ENOTSUP != errno))
+    {
+      allTestsOk = false;
+      Serial.print("[FAIL] Register unplug callback for SD Card test failed");
+      Serial.println();
+    }
+  }
+  // <-- Register unplug callback for SD Card test
+
+  if (DEV_USB == deviceName)
+  {
+    // Register nullptr callback test (hotplug) -->
     retVal = register_hotplug_callback(DEV_USB, nullptr);
     if ((-1 != retVal) || (EFAULT != errno))
     {
       allTestsOk = false;
-      Serial.print("[FAIL] Register nullptr callback test failed");
+      Serial.print("[FAIL] Register nullptr callback test failed (hotplug)");
       Serial.println();
     }
-    // <-- Register nullptr callback test
-  }
+    // <-- Register nullptr callback test (hotplug)
 
-  if ((TEST_PORTENTA_H7_USB == selectedTest) || (TEST_PORTENTA_MACHINE_CONTROL_USB == selectedTest) || (TEST_OPTA_USB == selectedTest))
-  {
-    // Register unsupported callback test -->
-    retVal = register_hotplug_callback(DEV_USB, usbCallback);
-    if ((-1 != retVal) || (ENOTSUP != errno))
+    // Register nullptr callback test (unplug) -->
+    retVal = register_unplug_callback(DEV_USB, nullptr);
+    if ((-1 != retVal) || (EFAULT != errno))
     {
       allTestsOk = false;
-      Serial.println("[FAIL] Register unsupported callback test");
+      Serial.print("[FAIL] Register nullptr callback test failed (unplug)");
       Serial.println();
     }
-    // <-- Register unsupported callback test
+    // <-- Register nullptr callback test (unplug)
   }
 
-  // This isn't a test, just wait for a USB thumb drive -->
+  // Wait for a USB thumb drive -->
   if (DEV_USB == deviceName)
   {
     Serial.println("Please insert a thumb drive");
-    if (TEST_PORTENTA_C33_USB == selectedTest)
-    {
-      // This board supports hotplug callbacks
-      (void) register_hotplug_callback(DEV_USB, usbCallback);
-      while (false == usbAttached) {
-        delay(500);
-      }
-    }
-    else if ((TEST_PORTENTA_H7_USB == selectedTest) || (TEST_PORTENTA_MACHINE_CONTROL_USB == selectedTest) || (TEST_OPTA_USB == selectedTest))
-    {
-      // These boards don't support hotplug callbacks, so loop on mount() tries
-      while (0 != mount(DEV_USB, FS_FAT, MNT_DEFAULT)) {
-        delay(500);
-      }
-      (void) umount(DEV_USB);
-    }
-    else
-    {
-      for ( ; ;) ;  // Shouldn't get here unless there's a bug in the test code
+    (void) register_hotplug_callback(DEV_USB, usbCallback);
+    while (false == usbAttached) {
+      delay(500);
     }
     Serial.println("Thank you!");
     Serial.println();
   }
-  // <-- This isn't a test, just wait for a USB thumb drive
+  // <-- Wait for a USB thumb drive
   
 #if defined(PERFORM_FORMATTING_TESTS)
   Serial.println("The formatting tests you selected can take a while to complete");
@@ -335,26 +336,35 @@ void setup() {
   (void) umount(deviceName);
   // <-- mount() when already mounted test
 
-  if (TEST_PORTENTA_C33_USB == selectedTest)
+  if (DEV_USB == deviceName)
   {
-    // Register multiple callbacks test -->
+    // Register multiple callbacks test (hotplug) -->
     retVal = register_hotplug_callback(DEV_USB, usbCallback);
     if ((-1 != retVal) || (EBUSY != errno))
     {
       allTestsOk = false;
-      Serial.println("[FAIL] Register multiple callbacks test failed");
+      Serial.println("[FAIL] Register multiple callbacks test failed (hotplug)");
     }
-    // <-- Register multiple callbacks test
+    // <-- Register multiple callbacks test (hotplug)
   }
 
-  // Deregister callback not supported test -->
+  // Deregister callback not supported test (hotplug) -->
   retVal = deregister_hotplug_callback(DEV_USB);
   if ((-1 != retVal) || (ENOSYS != errno))
   {
     allTestsOk = false;
     Serial.println("[FAIL] Deregister callback not supported test failed");
   }
-  // <-- Deregister callback not supported test
+  // <-- Deregister callback not supported test (hotplug)
+
+  // Deregister callback not supported test (unplug) -->
+  retVal = deregister_unplug_callback(DEV_USB);
+  if ((-1 != retVal) || (ENOSYS != errno))
+  {
+    allTestsOk = false;
+    Serial.println("[FAIL] Deregister callback not supported test failed");
+  }
+  // <-- Deregister callback not supported test (unplug)
 
   // Remove before persistent storage test -->
   (void) mount(deviceName, FS_FAT, MNT_DEFAULT);
@@ -450,6 +460,31 @@ void setup() {
   }
   (void) umount(deviceName);
   // <-- Persistent storage test
+
+  // Wait for USB thumb drive removal -->
+  if (DEV_USB == deviceName)
+  {
+    Serial.println();
+    Serial.println("Please remove the thumb drive");
+    (void) register_unplug_callback(DEV_USB, usbCallback2);
+    while (false == usbDetached) {
+      delay(500);
+    }
+    Serial.println("Thank you!");
+  }
+  // <-- Wait for USB thumb drive removal
+
+  if (DEV_USB == deviceName)
+  {
+    // Register multiple callbacks test (unplug) -->
+    retVal = register_unplug_callback(DEV_USB, usbCallback);
+    if ((-1 != retVal) || (EBUSY != errno))
+    {
+      allTestsOk = false;
+      Serial.println("[FAIL] Register multiple callbacks test failed (unplug)");
+    }
+    // <-- Register multiple callbacks test (unplug)
+  }
 
   // Final report -->
   Serial.println();

--- a/extras/tests/Arduino_POSIXStorage_Test/Arduino_POSIXStorage_Test.ino
+++ b/extras/tests/Arduino_POSIXStorage_Test/Arduino_POSIXStorage_Test.ino
@@ -24,13 +24,13 @@ enum TestTypes : uint8_t
 
 // !!! TEST CONFIGURATION !!! -->
 
-constexpr enum TestTypes selectedTest = TEST_PORTENTA_C33_SDCARD;
+constexpr enum TestTypes selectedTest = TEST_PORTENTA_C33_USB;
 
 // Notice that formtting tests can take a while to complete
 
 // Uncomment the line below to include testing of LITTLEFS and FAT formatting with mkfs():
 
-//#define PERFORM_FORMATTING_TESTS
+#define PERFORM_FORMATTING_TESTS
 
 // <-- !!! TEST CONFIGURATION !!!
 
@@ -461,29 +461,33 @@ void setup() {
   (void) umount(deviceName);
   // <-- Persistent storage test
 
-  // Wait for USB thumb drive removal -->
-  if (DEV_USB == deviceName)
+  // These tests can't be performed on the Opta because we log to USB
+  if (TEST_OPTA_USB != selectedTest)
   {
-    Serial.println();
-    Serial.println("Please remove the thumb drive");
-    (void) register_unplug_callback(DEV_USB, usbCallback2);
-    while (false == usbDetached) {
-      delay(500);
-    }
-    Serial.println("Thank you!");
-  }
-  // <-- Wait for USB thumb drive removal
-
-  if (DEV_USB == deviceName)
-  {
-    // Register multiple callbacks test (unplug) -->
-    retVal = register_unplug_callback(DEV_USB, usbCallback2);
-    if ((-1 != retVal) || (EBUSY != errno))
+    // Wait for USB thumb drive removal -->
+    if (DEV_USB == deviceName)
     {
-      allTestsOk = false;
-      Serial.println("[FAIL] Register multiple callbacks test failed (unplug)");
+      Serial.println();
+      Serial.println("Please remove the thumb drive");
+      (void) register_unplug_callback(DEV_USB, usbCallback2);
+      while (false == usbDetached) {
+        delay(500);
+      }
+      Serial.println("Thank you!");
     }
-    // <-- Register multiple callbacks test (unplug)
+    // <-- Wait for USB thumb drive removal
+
+    if (DEV_USB == deviceName)
+    {
+      // Register multiple callbacks test (unplug) -->
+      retVal = register_unplug_callback(DEV_USB, usbCallback2);
+      if ((-1 != retVal) || (EBUSY != errno))
+      {
+        allTestsOk = false;
+        Serial.println("[FAIL] Register multiple callbacks test failed (unplug)");
+      }
+      // <-- Register multiple callbacks test (unplug)
+    }
   }
 
   // Final report -->

--- a/extras/tests/Arduino_POSIXStorage_Test/Arduino_POSIXStorage_Test.ino
+++ b/extras/tests/Arduino_POSIXStorage_Test/Arduino_POSIXStorage_Test.ino
@@ -30,7 +30,7 @@ constexpr enum TestTypes selectedTest = TEST_PORTENTA_C33_SDCARD;
 
 // Uncomment the line below to include testing of LITTLEFS and FAT formatting with mkfs():
 
-#define PERFORM_FORMATTING_TESTS
+//#define PERFORM_FORMATTING_TESTS
 
 // <-- !!! TEST CONFIGURATION !!!
 

--- a/extras/tests/Arduino_POSIXStorage_Test/Arduino_POSIXStorage_Test.ino
+++ b/extras/tests/Arduino_POSIXStorage_Test/Arduino_POSIXStorage_Test.ino
@@ -353,7 +353,7 @@ void setup() {
   if ((-1 != retVal) || (ENOSYS != errno))
   {
     allTestsOk = false;
-    Serial.println("[FAIL] Deregister callback not supported test failed");
+    Serial.println("[FAIL] Deregister callback not supported test failed (hotplug)");
   }
   // <-- Deregister callback not supported test (hotplug)
 
@@ -362,7 +362,7 @@ void setup() {
   if ((-1 != retVal) || (ENOSYS != errno))
   {
     allTestsOk = false;
-    Serial.println("[FAIL] Deregister callback not supported test failed");
+    Serial.println("[FAIL] Deregister callback not supported test failed (unplug)");
   }
   // <-- Deregister callback not supported test (unplug)
 

--- a/extras/tests/Arduino_POSIXStorage_Test/Arduino_POSIXStorage_Test.ino
+++ b/extras/tests/Arduino_POSIXStorage_Test/Arduino_POSIXStorage_Test.ino
@@ -18,13 +18,13 @@ enum TestTypes : uint8_t
   TEST_PORTENTA_H7_USB,
   TEST_PORTENTA_MACHINE_CONTROL_SDCARD,
   TEST_PORTENTA_MACHINE_CONTROL_USB,
-  TEST_OPTA_SDCARD,
-  TEST_OPTA_USB
+  TEST_OPTA_SDCARD,   // Not currently implemented
+  TEST_OPTA_USB       // Logging to thumb drive
 };
 
 // !!! TEST CONFIGURATION !!! -->
 
-constexpr enum TestTypes selectedTest = TEST_PORTENTA_C33_USB;
+constexpr enum TestTypes selectedTest = TEST_PORTENTA_C33_SDCARD;
 
 // Notice that formtting tests can take a while to complete
 
@@ -77,13 +77,15 @@ void setup() {
   Serial.println("Testing started, please wait...");
   Serial.println();
 
-  if ((TEST_PORTENTA_MACHINE_CONTROL_SDCARD == selectedTest) || (TEST_OPTA_SDCARD == selectedTest))
+  if (TEST_PORTENTA_MACHINE_CONTROL_SDCARD == selectedTest)
   {
-    // Machine Control and Opta no SD Card supported test -->
+    // Machine Control no SD Card supported test -->
     retVal = mount(DEV_SDCARD, FS_FAT, MNT_DEFAULT);
     if ((-1 != retVal) || (ENOTBLK != errno))
     {
-      Serial.println("[FAIL] Machine Control and Opta no SD Card supported test failed");
+      Serial.println("[FAIL] Machine Control no SD Card supported test failed");
+      Serial.println();
+      Serial.println("FAILURE: Finished with errors (see list above for details)");
     }
     else
     {
@@ -91,8 +93,8 @@ void setup() {
       Serial.println();
       Serial.println("SUCCESS: Finished without errors");
       (void) umount(DEV_SDCARD);
-      for ( ; ; ) ;   // Stop testing here
     }
+    for ( ; ; ) ;   // Stop testing here
     // <-- Machine Control and Opta no SD Card supported test
   }
 
@@ -507,7 +509,7 @@ void setup() {
   // Opta final report -->
   if (TEST_OPTA_USB == selectedTest)
   {
-    (void) mount(deviceName, FS_FAT, MNT_DEFAULT);
+    (void) mount(DEV_USB, FS_FAT, MNT_DEFAULT);
     FILE *logFile = fopen("/usb/testlog.txt", "w");
     if (true == allTestsOk)
     {
@@ -519,7 +521,7 @@ void setup() {
       fprintf(logFile, "FAILURE: Finished with errors");
       fclose(logFile);      
     }
-    (void) umount(deviceName);
+    (void) umount(DEV_USB);
   }
   // <--
 }

--- a/src/Arduino_POSIXStorage.cpp
+++ b/src/Arduino_POSIXStorage.cpp
@@ -243,7 +243,7 @@ enum BoardTypes detectBoardType()
 void portentaMachineControlPowerHandling()
 {
   // Determine if we're running on Machine Control or not on the first call to mount(), mkfs(),
-  // register_hotplug_callback(), or register_unplug_callback()  -->
+  // register_hotplug_callback(), or register_unplug_callback()
   if (false == hasMountedBefore)
   {
     hasMountedBefore = true;
@@ -251,16 +251,15 @@ void portentaMachineControlPowerHandling()
     {
       runningOnMachineControl = true;
     }
-  }
-  // <--
 #if defined(ARDUINO_PORTENTA_H7_M7)
-  if (true == runningOnMachineControl)
-  {
-    // We need to apply power manually to the female USB A connector on the Machine Control
-    mbed::DigitalOut enablePower(PB_14, 0);
-  }
+    if (true == runningOnMachineControl)
+    {
+      // We need to apply power manually to the female USB A connector on the Machine Control
+      mbed::DigitalOut enablePower(PB_14, 0);
+    }
 #endif
-} // End of portentaMachineControl()
+  }
+} // End of portentaMachineControlPowerHandling()
 
 void deleteDevice(const enum StorageDevices deviceName, struct DeviceFileSystemCombination * const deviceFileSystemCombination)
 {
@@ -556,7 +555,7 @@ int register_callback(const enum StorageDevices deviceName, void (* const callba
         // base-class object, and dynamic_cast wouldn't work anyway because compilation is done with -fno-rtti
         usbHostDevice = static_cast<USBHostMSD*>(usb.device);
       }
-      bool attachCallbackReturn = false;
+      bool attachCallbackReturn;
       if (CALLBACK_HOTPLUG == callbackType)
       {
         attachCallbackReturn = usbHostDevice->attach_detected_callback(callbackFunction);
@@ -657,7 +656,7 @@ int umount(const enum StorageDevices deviceName)
     return -1;
   }
   // See note (1) at the bottom of the file
-  int unmountRet = deviceFileSystemCombination->fileSystem->unmount();
+  const int unmountRet = deviceFileSystemCombination->fileSystem->unmount();
   if (0 == unmountRet)
   {
     // Ok to delete with base class pointer because the destructor of the base class is virtual
@@ -682,13 +681,10 @@ int register_hotplug_callback(const enum StorageDevices deviceName, void (* cons
     errno = callbackReturn;
     return -1;
   }
-  else
-  {
-    return 0;
-  }
+  return 0;
 }   // End of register_hotplug_callback()
 
-// Not supported by the layer below on these platforms, but might be on other platforms
+// Currently not supported on any platform, but might be in the future
 int deregister_hotplug_callback(const enum StorageDevices deviceName)
 {
   (void) deviceName;    // Remove when implemented, only here to silence -Wunused-parameter
@@ -704,13 +700,10 @@ int register_unplug_callback(const enum StorageDevices deviceName, void (* const
     errno = callbackReturn;
     return -1;
   }
-  else
-  {
-    return 0;
-  }
-}   // End of register__unplug_callback()
+  return 0;
+}   // End of register_unplug_callback()
 
-// Not supported by the layer below on these platforms, but might be on other platforms
+// Currently not supported on any platform, but might be in the future
 int deregister_unplug_callback(const enum StorageDevices deviceName)
 {
   (void) deviceName;    // Remove when implemented, only here to silence -Wunused-parameter

--- a/src/Arduino_POSIXStorage.h
+++ b/src/Arduino_POSIXStorage.h
@@ -135,7 +135,7 @@ int mount(const enum StorageDevices deviceName,
 int umount(const enum StorageDevices deviceName);
 
 /**
-* @brief Register a hotplug callback function. Currently only supported for DEV_USB on Portenta C33.
+* @brief Register a hotplug callback function.
 * @param deviceName The device to register for: DEV_SDCARD or DEV_USB.
 * @param callbackFunction A function pointer to the callback.
 * @return On success: 0. On failure: -1 with an error code in the errno variable.
@@ -148,6 +148,21 @@ int register_hotplug_callback(const enum StorageDevices deviceName, void (* cons
 * @return On success: 0. On failure: -1 with an error code in the errno variable.
 */
 int deregister_hotplug_callback(const enum StorageDevices deviceName);
+
+/**
+* @brief Register an unplug callback function.
+* @param deviceName The device to register for: DEV_SDCARD or DEV_USB.
+* @param callbackFunction A function pointer to the callback.
+* @return On success: 0. On failure: -1 with an error code in the errno variable.
+*/
+int register_unplug_callback(const enum StorageDevices deviceName, void (* const callbackFunction)());
+
+/**
+* @brief Deregister a previously registered unplug callback function. Not currently supported on any platform.
+* @param deviceName The device to deregister for: DEV_SDCARD or DEV_USB.
+* @return On success: 0. On failure: -1 with an error code in the errno variable.
+*/
+int deregister_unplug_callback(const enum StorageDevices deviceName);
 
 /**
 * @brief Format a device (make file system).


### PR DESCRIPTION
Adds support for register_hotplug_callback() on H7 boards, and functionality to register a
disconnect callback on all platforms. Also updates the tests and documentation accordingly.