### PR TITLE
Correct outdated library name references

### DIFF
--- a/extras/tests/Arduino_POSIXStorage_Test/Arduino_POSIXStorage_Test.ino
+++ b/extras/tests/Arduino_POSIXStorage_Test/Arduino_POSIXStorage_Test.ino
@@ -1,6 +1,6 @@
 /*
  *
- * POSIXStorage Tests
+ * Arduino_POSIXStorage Tests
  *
  * Original Author: A. Vidstrom (Arduino SA. http://arduino.cc)
  *

--- a/src/Arduino_POSIXStorage.cpp
+++ b/src/Arduino_POSIXStorage.cpp
@@ -69,7 +69,7 @@
   #include <Arduino_USBHostMbed5.h>
   #include <BlockDevice.h>
 #else
-  #error "The POSIXStorage library does not support this board"
+  #error "The Arduino_POSIXStorage library does not support this board"
 #endif
 
 /*

--- a/src/Arduino_POSIXStorage.h
+++ b/src/Arduino_POSIXStorage.h
@@ -57,7 +57,7 @@
 *********************************************************************************************************
 */
 
-// These are necesssary to expose to the sketch to get the retargeting from mbed -->
+// These are necessary to expose to the sketch to get the retargeting from mbed -->
 
 #if defined(ARDUINO_PORTENTA_H7_M7) || defined(ARDUINO_OPTA)
   #include <mbed.h>
@@ -74,7 +74,7 @@
 *********************************************************************************************************
 */
 
-// These are necesssary to expose to the sketch to get the retargeting from mbed -->
+// These are necessary to expose to the sketch to get the retargeting from mbed -->
 
 #if defined(ARDUINO_PORTENTA_H7_M7) || defined(ARDUINO_OPTA)
   using mbed::FATFileSystem;


### PR DESCRIPTION
The [**codespell**](https://github.com/codespell-project/codespell) spellchecker tool is used to automatically detect commonly misspelled words in the files of this project.

The misspelled words dictionary was expanded in the [latest release](https://github.com/codespell-project/codespell/releases/tag/v2.3.0) of codespell, which resulted in the detection of
misspelled words in the project's comments:

https://github.com/arduino-libraries/Arduino_POSIXStorage/actions/runs/9265735166

The typos are hereby corrected, which will restore the spell check to a passing state.